### PR TITLE
Update index.html

### DIFF
--- a/tests/index.html
+++ b/tests/index.html
@@ -13,7 +13,7 @@
             {
                 "imports": {
                     "freeshow-api": "../dist/index.js",
-                    "socket.io-client": "../node_modules/socket.io-client/dist/socket.io.esm.min.js"
+                    "socket.io-client": "../../socket.io-client/dist/socket.io.esm.min.js"
                 }
             }
         </script>


### PR DESCRIPTION
Line 16 of index.html reads:
~~~
"socket.io-client": "../node_modules/socket.io-client/dist/socket.io.esm.min.js"
~~~

I installed npm on my Windows 11 machine. I created and entered a directory. I then installed the freeshow-api with npm install freeshow-api. The index.html page did not work because it couldn't find socket.io.esm.min.js. The node_modules folder is more than one directory up. In my setup, the line needs to read as below:

~~~
"socket.io-client": "../../socket.io-client/dist/socket.io.esm.min.js"
~~~

